### PR TITLE
Added the possibility to override the webservice location

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,6 @@ Passing a `$function` not defined in the WSDL file will throw a `SoapFault`.
 This method allows you to change the destination of your SOAP calls. It does not change the Client object, but returns a new
 Client with the overriden target.
 
-#### getWsdlTarget()
-
-This method allows you to retrieve the target URL specified in the WSDL file.
-
 ### Proxy
 
 The `Proxy` class wraps an existing [`Client`](#client) instance in order to ease calling

--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ assert('http://example.com/soap/service' == $client->getLocation(0));
 
 Passing a `$function` not defined in the WSDL file will throw a `SoapFault`. 
 
-#### overrideTarget($newTarget)
+#### withOverridenTarget($newTarget)
 
-This method allows you to change the destination of your SOAP calls.
+This method allows you to change the destination of your SOAP calls. It does not change the Client object, but returns a new
+Client with the overriden target.
 
 #### getWsdlTarget()
 

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ assert('http://example.com/soap/service' == $client->getLocation(0));
 
 Passing a `$function` not defined in the WSDL file will throw a `SoapFault`. 
 
-#### withTarget($newTarget)
+#### withRequestTarget($requestTarget)
 
-This method allows you to change the destination of your SOAP calls. It does not change the Client object, but returns a new
-Client with the overriden target.
+This method allows you to change the destination of your SOAP calls. It returns a new Client instance
+with the specified request-target.
 
 ### Proxy
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ assert('http://example.com/soap/service' == $client->getLocation(0));
 
 Passing a `$function` not defined in the WSDL file will throw a `SoapFault`. 
 
-#### withOverridenTarget($newTarget)
+#### withTarget($newTarget)
 
 This method allows you to change the destination of your SOAP calls. It does not change the Client object, but returns a new
 Client with the overriden target.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ assert('http://example.com/soap/service' == $client->getLocation(0));
 
 Passing a `$function` not defined in the WSDL file will throw a `SoapFault`. 
 
+#### overrideTarget($newTarget)
+
+This method allows you to change the destination of your SOAP calls.
+
+#### getWsdlTarget()
+
+This method allows you to retrieve the target URL specified in the WSDL file.
+
 ### Proxy
 
 The `Proxy` class wraps an existing [`Client`](#client) instance in order to ease calling

--- a/src/Client.php
+++ b/src/Client.php
@@ -103,10 +103,10 @@ class Client
         return (string)$this->encoder->encode($function, array())->getUri();
     }
 
-    public function overrideTarget($target)
+    public function withOverridenTarget($target)
     {
         $copy = clone $this;
-        $copy->encoder = $this->encoder->overrideTarget($target);
+        $copy->encoder = $this->encoder->withOverridenTarget($target);
         return $copy;
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -50,7 +50,7 @@ class Client
 
     public function handleResponse(ResponseInterface $response)
     {
-        return $this->decoder->decode((string) $response->getBody());
+        return $this->decoder->decode((string)$response->getBody());
     }
 
     public function handleError(Exception $error)
@@ -103,10 +103,11 @@ class Client
         return (string)$this->encoder->encode($function, array())->getUri();
     }
 
-    public function withTarget($target)
+    public function withRequestTarget($requestTarget)
     {
         $copy = clone $this;
-        $copy->encoder = $this->encoder->withTarget($target);
+        $copy->encoder = $this->encoder->withRequestTarget($requestTarget);
+
         return $copy;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -103,10 +103,15 @@ class Client
         return (string)$this->encoder->encode($function, array())->getUri();
     }
 
-    public function overrideLocation($location)
+    public function overrideTarget($target)
     {
         $copy = clone $this;
-        $copy->encoder = $this->encoder->overrideLocation($location);
+        $copy->encoder = $this->encoder->overrideTarget($target);
         return $copy;
+    }
+
+    public function getWsdlTarget()
+    {
+        return $this->encoder->getWsdlTarget();
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -103,10 +103,10 @@ class Client
         return (string)$this->encoder->encode($function, array())->getUri();
     }
 
-    public function withOverridenTarget($target)
+    public function withTarget($target)
     {
         $copy = clone $this;
-        $copy->encoder = $this->encoder->withOverridenTarget($target);
+        $copy->encoder = $this->encoder->withTarget($target);
         return $copy;
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -102,4 +102,11 @@ class Client
         // encode request for given $function
         return (string)$this->encoder->encode($function, array())->getUri();
     }
+
+    public function overrideLocation($location)
+    {
+        $copy = clone $this;
+        $copy->encoder = $this->encoder->overrideLocation($location);
+        return $copy;
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -50,7 +50,7 @@ class Client
 
     public function handleResponse(ResponseInterface $response)
     {
-        return $this->decoder->decode((string)$response->getBody());
+        return $this->decoder->decode((string) $response->getBody());
     }
 
     public function handleError(Exception $error)
@@ -108,10 +108,5 @@ class Client
         $copy = clone $this;
         $copy->encoder = $this->encoder->withTarget($target);
         return $copy;
-    }
-
-    public function getWsdlTarget()
-    {
-        return $this->encoder->getWsdlTarget();
     }
 }

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -47,7 +47,7 @@ class ClientEncoder extends SoapClient
         return '';
     }
 
-    public function withOverridenTarget($newTarget)
+    public function withTarget($newTarget)
     {
         $copy = clone $this;
         $this->targetOverride = $newTarget;

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -50,7 +50,7 @@ class ClientEncoder extends SoapClient
     public function withTarget($newTarget)
     {
         $copy = clone $this;
-        $this->targetOverride = $newTarget;
+        $copy->targetOverride = $newTarget;
         return $copy;
     }
 

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -9,8 +9,6 @@ class ClientEncoder extends SoapClient
 {
     private $request        = null;
     private $targetOverride = null;
-    private $target         = null;
-    private $findTarget     = false;
 
     public function encode($name, $args)
     {
@@ -25,23 +23,18 @@ class ClientEncoder extends SoapClient
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
 
-        if ($this->findTarget) {
-            $this->target     = (string) $location;
-            $this->findTarget = false;
-        } else {
-            $finalLocation = $this->targetOverride !== null ? $this->targetOverride : $location;
+        $finalLocation = $this->targetOverride !== null ? $this->targetOverride : $location;
 
-            $this->request = new Request(
-                'POST',
-                (string) $finalLocation,
-                new Headers(array(
-                    'SOAPAction' => (string) $action,
-                    'Content-Type' => 'text/xml; charset=utf-8',
-                    'Content-Length' => strlen($request)
-                )),
-                new Body((string) $request)
-            );
-        }
+        $this->request = new Request(
+            'POST',
+            (string) $finalLocation,
+            new Headers(array(
+                'SOAPAction' => (string) $action,
+                'Content-Type' => 'text/xml; charset=utf-8',
+                'Content-Length' => strlen($request)
+            )),
+            new Body((string) $request)
+        );
 
         // do not actually block here, just pretend we're done...
         return '';
@@ -53,26 +46,4 @@ class ClientEncoder extends SoapClient
         $copy->targetOverride = $newTarget;
         return $copy;
     }
-
-    public function getWsdlTarget()
-    {
-        /*
-        * We can't just use a function with an empty name.
-        * SoapClient complains if the request does not exist.
-        */
-        $functionDescriptions = $this->__getFunctions();
-        $functionDescription = $functionDescriptions[0]; /* PHP 5.3 support. */
-        $spaceIndex = strpos($functionDescription, ' ');
-        $openingParenIndex = strpos($functionDescription, '(');
-        $function = substr(
-            $functionDescription,
-            $spaceIndex + 1,
-            $openingParenIndex - $spaceIndex - 1
-        );
-
-        $this->findTarget = true;
-        $this->__soapCall($function, array());
-        return $this->target;
-    }
-
 }

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -26,7 +26,7 @@ class ClientEncoder extends SoapClient
     {
 
         if ($this->findTarget) {
-            $this->target     = $location;
+            $this->target     = (string) $location;
             $this->findTarget = false;
         } else {
             $finalLocation = $this->targetOverride !== null ? $this->targetOverride : $location;
@@ -71,7 +71,7 @@ class ClientEncoder extends SoapClient
         );
 
         $this->findTarget = true;
-        $this->__soapCall($function, array());
+        $this->__soapCall($function, []);
         return $this->target;
     }
 

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -71,7 +71,7 @@ class ClientEncoder extends SoapClient
         );
 
         $this->findTarget = true;
-        $this->__soapCall($function, []);
+        $this->__soapCall($function, array());
         return $this->target;
     }
 

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -47,7 +47,7 @@ class ClientEncoder extends SoapClient
         return '';
     }
 
-    public function overrideTarget($newTarget)
+    public function withOverridenTarget($newTarget)
     {
         $copy = clone $this;
         $this->targetOverride = $newTarget;

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -7,8 +7,8 @@ use RingCentral\Psr7\Request;
 
 class ClientEncoder extends SoapClient
 {
-    private $request        = null;
-    private $targetOverride = null;
+    private $request       = null;
+    private $requestTarget = null;
 
     public function encode($name, $args)
     {
@@ -23,27 +23,28 @@ class ClientEncoder extends SoapClient
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
 
-        $finalLocation = $this->targetOverride !== null ? $this->targetOverride : $location;
+        $requestTarget = $this->requestTarget !== null ? $this->requestTarget : $location;
 
         $this->request = new Request(
             'POST',
-            (string) $finalLocation,
-            new Headers(array(
-                'SOAPAction' => (string) $action,
+            (string)$requestTarget,
+            array(
+                'SOAPAction' => (string)$action,
                 'Content-Type' => 'text/xml; charset=utf-8',
                 'Content-Length' => strlen($request)
-            )),
-            new Body((string) $request)
+            ),
+            (string)$request
         );
 
         // do not actually block here, just pretend we're done...
         return '';
     }
 
-    public function withTarget($newTarget)
+    public function withRequestTarget($requestTarget)
     {
         $copy = clone $this;
-        $copy->targetOverride = $newTarget;
+        $copy->requestTarget = $requestTarget;
+
         return $copy;
     }
 }

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -7,8 +7,10 @@ use RingCentral\Psr7\Request;
 
 class ClientEncoder extends SoapClient
 {
-    private $request          = null;
-    private $locationOverride = null;
+    private $request        = null;
+    private $targetOverride = null;
+    private $target         = null;
+    private $findTarget     = false;
 
     public function encode($name, $args)
     {
@@ -22,27 +24,55 @@ class ClientEncoder extends SoapClient
 
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
-        $finalLocation = $this->locationOverride !== null ? $this->locationOverride : $location;
 
-        $this->request = new Request(
-            'POST',
-            (string)$finalLocation,
-            array(
-                'SOAPAction' => (string)$action,
-                'Content-Type' => 'text/xml; charset=utf-8',
-                'Content-Length' => strlen($request)
-            ),
-            (string)$request
-        );
+        if ($this->findTarget) {
+            $this->target     = $location;
+            $this->findTarget = false;
+        } else {
+            $finalLocation = $this->targetOverride !== null ? $this->targetOverride : $location;
+
+            $this->request = new Request(
+                'POST',
+                (string) $finalLocation,
+                new Headers(array(
+                    'SOAPAction' => (string) $action,
+                    'Content-Type' => 'text/xml; charset=utf-8',
+                    'Content-Length' => strlen($request)
+                )),
+                new Body((string) $request)
+            );
+        }
 
         // do not actually block here, just pretend we're done...
         return '';
     }
 
-    public function overrideLocation($newLocation)
+    public function overrideTarget($newTarget)
     {
         $copy = clone $this;
-        $this->locationOverride = $newLocation;
+        $this->targetOverride = $newTarget;
         return $copy;
     }
+
+    public function getWsdlTarget()
+    {
+        /*
+        * We can't just use a function with an empty name.
+        * SoapClient complains if the request does not exist.
+        */
+        $functionDescriptions = $this->__getFunctions();
+        $functionDescription = $functionDescriptions[0]; /* PHP 5.3 support. */
+        $spaceIndex = strpos($functionDescription, ' ');
+        $openingParenIndex = strpos($functionDescription, '(');
+        $function = substr(
+            $functionDescription,
+            $spaceIndex + 1,
+            $openingParenIndex - $spaceIndex - 1
+        );
+
+        $this->findTarget = true;
+        $this->__soapCall($function, []);
+        return $this->target;
+    }
+
 }

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -7,7 +7,8 @@ use RingCentral\Psr7\Request;
 
 class ClientEncoder extends SoapClient
 {
-    private $request = null;
+    private $request          = null;
+    private $locationOverride = null;
 
     public function encode($name, $args)
     {
@@ -21,9 +22,11 @@ class ClientEncoder extends SoapClient
 
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
+        $finalLocation = $this->locationOverride !== null ? $this->locationOverride : $location;
+
         $this->request = new Request(
             'POST',
-            (string)$location,
+            (string)$finalLocation,
             array(
                 'SOAPAction' => (string)$action,
                 'Content-Type' => 'text/xml; charset=utf-8',
@@ -34,5 +37,12 @@ class ClientEncoder extends SoapClient
 
         // do not actually block here, just pretend we're done...
         return '';
+    }
+
+    public function overrideLocation($newLocation)
+    {
+        $copy = clone $this;
+        $this->locationOverride = $newLocation;
+        return $copy;
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -88,4 +88,24 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('http://www.thomas-bayer.com/axis2/services/BLZService', $this->client->getLocation(100));
     }
+
+    public function testWrongLocationOverride()
+    {
+        $this->client->overrideLocation('nonsense.not.existing');
+        $api = new Proxy($this->client);
+
+        $promise = $api->getBank(array('blz' => '12070000'));
+
+        $this->expectPromiseReject($promise);
+
+        $this->setExpectedException('Exception');
+        $this->waitForPromise($promise, $this->loop);
+    }
+
+    public function testCorrectLocationOverride()
+    {
+        $this->client->overrideLocation('nonsense.not.existing');
+        $this->client->overrideLocation('http://www.thomas-bayer.com/axis2/services/BLZService');
+        $this->testBlzService();
+    }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -91,7 +91,7 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
     public function testWrongLocationOverride()
     {
-        $this->client->overrideTarget('nonsense.not.existing');
+        $this->client->withOverridenTarget('nonsense.not.existing');
         $api = new Proxy($this->client);
 
         $promise = $api->getBank(array('blz' => '12070000'));
@@ -104,8 +104,8 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
     public function testCorrectLocationOverride()
     {
-        $this->client->overrideTarget('nonsense.not.existing');
-        $this->client->overrideTarget('http://www.thomas-bayer.com/axis2/services/BLZService');
+        $this->client->withOverridenTarget('nonsense.not.existing');
+        $this->client->withOverridenTarget('http://www.thomas-bayer.com/axis2/services/BLZService');
         $this->testBlzService();
     }
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -91,7 +91,7 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
     public function testWrongLocationOverride()
     {
-        $this->client->withOverridenTarget('nonsense.not.existing');
+        $this->client->withTarget('nonsense.not.existing');
         $api = new Proxy($this->client);
 
         $promise = $api->getBank(array('blz' => '12070000'));
@@ -104,8 +104,8 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
     public function testCorrectLocationOverride()
     {
-        $this->client->withOverridenTarget('nonsense.not.existing');
-        $this->client->withOverridenTarget('http://www.thomas-bayer.com/axis2/services/BLZService');
+        $this->client->withTarget('nonsense.not.existing');
+        $this->client->withTarget('http://www.thomas-bayer.com/axis2/services/BLZService');
         $this->testBlzService();
     }
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -89,22 +89,26 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.thomas-bayer.com/axis2/services/BLZService', $this->client->getLocation(100));
     }
 
-    public function testWrongLocationOverride()
+    public function testWrongRequestTarget()
     {
-        $api = new Proxy($this->client->withTarget('nonsense.not.existing'));
+        $api = new Proxy($this->client->withRequestTarget('nonsense.not.existing'));
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
-        $this->expectPromiseReject($promise);
-
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         Block\await($promise, $this->loop);
     }
 
-    public function testCorrectLocationOverride()
+    public function testCorrectRequestTarget()
     {
-        $this->client->withTarget('nonsense.not.existing');
-        $this->client->withTarget('http://www.thomas-bayer.com/axis2/services/BLZService');
-        $this->testBlzService();
+        $client = $this->client->withRequestTarget('nonsense.not.existing');
+        $client = $client->withRequestTarget('http://www.thomas-bayer.com/axis2/services/BLZService');
+        $api = new Proxy($client);
+
+        $promise = $api->getBank(array('blz' => '12070000'));
+
+        $result = Block\await($promise, $this->loop);
+
+        $this->assertInternalType('object', $result);
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -91,7 +91,7 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
     public function testWrongLocationOverride()
     {
-        $this->client->overrideLocation('nonsense.not.existing');
+        $this->client->overrideTarget('nonsense.not.existing');
         $api = new Proxy($this->client);
 
         $promise = $api->getBank(array('blz' => '12070000'));
@@ -104,8 +104,16 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
     public function testCorrectLocationOverride()
     {
-        $this->client->overrideLocation('nonsense.not.existing');
-        $this->client->overrideLocation('http://www.thomas-bayer.com/axis2/services/BLZService');
+        $this->client->overrideTarget('nonsense.not.existing');
+        $this->client->overrideTarget('http://www.thomas-bayer.com/axis2/services/BLZService');
         $this->testBlzService();
+    }
+
+    public function testGetLocation()
+    {
+        $this->assertEquals(
+            $this->client->getWsdlTarget(),
+            'http://www.thomas-bayer.com/axis2/services/BLZService'
+        );
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -91,8 +91,7 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
     public function testWrongLocationOverride()
     {
-        $this->client->withTarget('nonsense.not.existing');
-        $api = new Proxy($this->client);
+        $api = new Proxy($this->client->withTarget('nonsense.not.existing'));
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
@@ -107,13 +106,5 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
         $this->client->withTarget('nonsense.not.existing');
         $this->client->withTarget('http://www.thomas-bayer.com/axis2/services/BLZService');
         $this->testBlzService();
-    }
-
-    public function testGetLocation()
-    {
-        $this->assertEquals(
-            $this->client->getWsdlTarget(),
-            'http://www.thomas-bayer.com/axis2/services/BLZService'
-        );
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -98,7 +98,7 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
         $this->expectPromiseReject($promise);
 
         $this->setExpectedException('Exception');
-        $this->waitForPromise($promise, $this->loop);
+        Block\await($promise, $this->loop);
     }
 
     public function testCorrectLocationOverride()


### PR DESCRIPTION
Allows to use a custom request-target for soap requests. Based on work from @floriansimon1 in #7.

I rebased on master, fixed the unit tests and renamed withTarget() to withRequestTarget(). I think this name is better (same name is used in PSR-7: RequestInterface::withRequestTarget()).