### PR TITLE
Respect WSDL type definitions when decoding and support classmap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ $client = new Client($browser, $wsdl, array(
 ));
 ```
 
+You can use the `classmap` option to map certain WSDL types to PHP classes
+like this:
+
+```php
+$client = new Client($browser, $wsdl, array(
+    'classmap' => array(
+        'getBankResponseType' => BankResponse::class
+    )
+));
+```
+
 If you find an option is missing or not supported here, PRs are much
 appreciated!
 

--- a/src/Protocol/ClientDecoder.php
+++ b/src/Protocol/ClientDecoder.php
@@ -11,28 +11,24 @@ final class ClientDecoder extends SoapClient
 {
     private $response = null;
 
-    public function __construct()
-    {
-        // do not pass actual WSDL to parent constructor
-        // use faked non-wsdl-mode to let every method call pass through (pseudoCall)
-        parent::__construct(null, array('location' => '1', 'uri' => '2'));
-    }
-
     /**
      * Decodes the SOAP response / return value from the given SOAP envelope (HTTP response body)
      *
+     * @param string $function
      * @param string $response
      * @return mixed
      * @throws \SoapFault if response indicates a fault (error condition) or is invalid
      */
-    public function decode($response)
+    public function decode($function, $response)
     {
-        // temporarily save response internally for further processing
+        // Temporarily save response internally for further processing
         $this->response = $response;
 
-        // pretend we just invoked a SOAP function.
-        // internally, use the injected response to parse its results
-        $ret = $this->pseudoCall();
+        // Let's pretend we just invoked the given SOAP function.
+        // This won't actually invoke anything (see `__doRequest()`), but this
+        // requires a valid function name to match its definition in the WSDL.
+        // Internally, simply use the injected response to parse its results.
+        $ret = $this->__soapCall($function, array());
         $this->response = null;
 
         return $ret;

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -6,6 +6,10 @@ use Clue\React\Soap\Client;
 use Clue\React\Soap\Proxy;
 use PHPUnit\Framework\TestCase;
 
+class BankResponse
+{
+}
+
 /**
  * @group internet
  */
@@ -46,6 +50,30 @@ class FunctionalTest extends TestCase
         $result = Block\await($promise, $this->loop);
 
         $this->assertInternalType('object', $result);
+        $this->assertTrue(isset($result->details));
+        $this->assertTrue(isset($result->details->bic));
+    }
+
+    public function testBlzServiceWithClassmapReturnsExpectedType()
+    {
+        $this->client = new Client(new Browser($this->loop), self::$wsdl, array(
+            'classmap' => array(
+                'getBankResponseType' => 'BankResponse'
+            )
+        ));
+
+        $this->assertCount(2, $this->client->getFunctions());
+        $this->assertCount(3, $this->client->getTypes());
+
+        $api = new Proxy($this->client);
+
+        $promise = $api->getBank(array('blz' => '12070000'));
+
+        $result = Block\await($promise, $this->loop);
+
+        $this->assertInstanceOf('BankResponse', $result);
+        $this->assertTrue(isset($result->details));
+        $this->assertTrue(isset($result->details->bic));
     }
 
     public function testBlzServiceWithSoapV12()
@@ -64,14 +92,15 @@ class FunctionalTest extends TestCase
         $result = Block\await($promise, $this->loop);
 
         $this->assertInternalType('object', $result);
+        $this->assertTrue(isset($result->details));
+        $this->assertTrue(isset($result->details->bic));
     }
 
-    public function testBlzServiceNonWsdlMode()
+    public function testBlzServiceNonWsdlModeReturnedWithoutOuterResultStructure()
     {
         $this->client = new Client(new Browser($this->loop), null, array(
             'location' => 'http://www.thomas-bayer.com/axis2/services/BLZService',
             'uri' => 'http://thomas-bayer.com/blz/',
-            'use' => SOAP_LITERAL
         ));
 
         $api = new Proxy($this->client);
@@ -83,6 +112,8 @@ class FunctionalTest extends TestCase
         $result = Block\await($promise, $this->loop);
 
         $this->assertInternalType('object', $result);
+        $this->assertFalse(isset($result->details));
+        $this->assertTrue(isset($result->bic));
     }
 
     /**

--- a/tests/Protocol/ClientDecoderTest.php
+++ b/tests/Protocol/ClientDecoderTest.php
@@ -10,7 +10,26 @@ class ClientDecoderTest extends TestCase
      */
     public function testDecodeThrowsSoapFaultForInvalidResponse()
     {
-        $decoder = new ClientDecoder();
-        $decoder->decode('invalid');
+        $decoder = new ClientDecoder(null, array('location' => '1', 'uri' => '2'));
+        $decoder->decode('anything', 'invalid');
+    }
+
+    public function testDecodeMessageToObjectNonWsdl()
+    {
+        $decoder = new ClientDecoder(null, array('location' => '1', 'uri' => '2'));
+
+        $res = $decoder->decode('anything', <<<SOAP
+<?xml version='1.0' encoding='utf-8'?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><ns1:getBankResponse xmlns:ns1="http://thomas-bayer.com/blz/"><ns1:details><ns1:bezeichnung>Deutsche Bank Ld Brandenburg</ns1:bezeichnung><ns1:bic>DEUTDEBB160</ns1:bic><ns1:ort>Potsdam</ns1:ort><ns1:plz>14405</ns1:plz></ns1:details></ns1:getBankResponse></soapenv:Body></soapenv:Envelope>
+SOAP
+        );
+
+        $expected = new stdClass();
+        $expected->bezeichnung = 'Deutsche Bank Ld Brandenburg';
+        $expected->bic = 'DEUTDEBB160';
+        $expected->ort = 'Potsdam';
+        $expected->plz = '14405';
+
+        $this->assertEquals($expected, $res);
     }
 }


### PR DESCRIPTION
The `Client` now respects the WSDL type definition when decoding and supports the `classmap` option.

You can use the `classmap` option to map certain WSDL types to PHP classes
like this:

```php
$client = new Client($browser, $wsdl, array(
    'classmap' => array(
        'getBankResponseType' => BankResponse::class
    )
));
```

This is a BC break because the decoder did previously only use the WSDL type definitions for *encoding* the outgoing SOAP request messages, but not for *decoding* the incoming SOAP response messages.

Builds on top of #32 