### PR TITLE
Properly handle SOAP error responses, accept HTTP error responses and explicitly configure Browser to not follow any HTTP redirects 

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -158,8 +158,12 @@ final class Client
 
         // Accept HTTP responses with error status codes as valid responses.
         // This is done in order to process these error responses through the normal SOAP decoder.
+        // Additionally, we explicitly limit number of redirects to zero because following redirects makes little sense
+        // because it transforms the POST request to a GET one and hence loses the SOAP request body.
         $browser = $browser->withOptions(array(
-            'obeySuccessCode' => false
+            'obeySuccessCode' => false,
+            'followRedirects' => true,
+            'maxRedirects' => 0
         ));
 
         $this->browser = $browser;

--- a/src/Client.php
+++ b/src/Client.php
@@ -156,6 +156,12 @@ final class Client
     {
         $wsdl = $wsdlContents !== null ? 'data://text/plain;base64,' . base64_encode($wsdlContents) : null;
 
+        // Accept HTTP responses with error status codes as valid responses.
+        // This is done in order to process these error responses through the normal SOAP decoder.
+        $browser = $browser->withOptions(array(
+            'obeySuccessCode' => false
+        ));
+
         $this->browser = $browser;
         $this->encoder = new ClientEncoder($wsdl, $options);
         $this->decoder = new ClientDecoder($wsdl, $options);
@@ -199,7 +205,6 @@ final class Client
             }
         );
     }
-
 
     /**
      * Returns an array of functions defined in the WSDL.

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -45,6 +45,7 @@ class ClientTest extends TestCase
         };
         $promise = new Promise(function () { });
         $browser = $this->getMockBuilder('Clue\React\Buzz\Browser')->disableOriginalConstructor()->getMock();
+        $browser->expects($this->once())->method('withOptions')->willReturnSelf();
         $browser->expects($this->once())->method('send')->with($this->callback($verify))->willReturn($promise);
 
         $client = new Client($browser, null, array('location' => 'http://example.com', 'uri' => 'http://example.com/uri'));

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -117,9 +117,10 @@ class FunctionalTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException SoapFault
+     * @expectedExeptionMessage Keine Bank zur BLZ invalid gefunden!
      */
-    public function testBlzServiceWithInvalidBlz()
+    public function testBlzServiceWithInvalidBlzRejectsWithSoapFault()
     {
         $api = new Proxy($this->client);
 
@@ -129,13 +130,14 @@ class FunctionalTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException SoapFault
+     * @expectedExceptionMessage Function ("doesNotExist") is not a valid method for this service
      */
-    public function testBlzServiceWithInvalidMethod()
+    public function testBlzServiceWithInvalidMethodRejectsWithSoapFault()
     {
         $api = new Proxy($this->client);
 
-        $promise = $api->doesNotexist();
+        $promise = $api->doesNotExist();
 
         Block\await($promise, $this->loop);
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -117,6 +117,23 @@ class FunctionalTest extends TestCase
     }
 
     /**
+     * @expectedException RuntimeException
+     * @expectedExeptionMessage redirects
+     */
+    public function testBlzServiceWithRedirectLocationRejectsWithRuntimeException()
+    {
+        $this->client = new Client(new Browser($this->loop), null, array(
+            'location' => 'http://httpbin.org/redirect-to?url=' . rawurlencode('http://www.thomas-bayer.com/axis2/services/BLZService'),
+            'uri' => 'http://thomas-bayer.com/blz/',
+        ));
+
+        $api = new Proxy($this->client);
+        $promise = $api->getBank('a');
+
+        $result = Block\await($promise, $this->loop);
+    }
+
+    /**
      * @expectedException SoapFault
      * @expectedExeptionMessage Keine Bank zur BLZ invalid gefunden!
      */


### PR DESCRIPTION
Builds on top of #34
Resolves / closes #3
Resolves / closes #2