### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -19,10 +19,9 @@ matrix:
   allow_failures:
     - php: hhvm-3.18
 
-sudo: false
-
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
     },
     "require-dev": {
         "clue/block-react": "^1.0",
-        "phpunit/phpunit": "^9.0 || ^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
     },
     "require-dev": {
         "clue/block-react": "^1.0",
-        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.0 || ^6.4 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
-        <testsuite>
+        <testsuite name="Soap Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Soap Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -127,7 +127,7 @@ class FunctionalTest extends TestCase
     public function testBlzServiceWithRedirectLocationRejectsWithRuntimeException()
     {
         $this->client = new Client(new Browser($this->loop), null, array(
-            'location' => 'http://httpbin.org/redirect-to?url=' . rawurlencode('http://www.thomas-bayer.com/axis2/services/BLZService'),
+            'location' => 'http://httpbingo.org/redirect-to?url=' . rawurlencode('http://www.thomas-bayer.com/axis2/services/BLZService'),
             'uri' => 'http://thomas-bayer.com/blz/',
         ));
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -29,12 +29,18 @@ class FunctionalTest extends TestCase
 
     // download WSDL file only once for all test cases
     private static $wsdl;
-    public static function setUpBeforeClass()
+    /**
+     * @beforeClass
+     */
+    public static function setUpFileBeforeClass()
     {
         self::$wsdl = file_get_contents('http://www.thomas-bayer.com/axis2/services/BLZService?wsdl');
     }
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpClient()
     {
         $this->loop = \React\EventLoop\Factory::create();
         $this->client = new Client(new Browser($this->loop), self::$wsdl);
@@ -51,7 +57,7 @@ class FunctionalTest extends TestCase
 
         $result = Block\await($promise, $this->loop);
 
-        $this->assertInternalType('object', $result);
+        $this->assertIsTypeObject($result);
         $this->assertTrue(isset($result->details));
         $this->assertTrue(isset($result->details->bic));
     }
@@ -93,7 +99,7 @@ class FunctionalTest extends TestCase
 
         $result = Block\await($promise, $this->loop);
 
-        $this->assertInternalType('object', $result);
+        $this->assertIsTypeObject($result);
         $this->assertTrue(isset($result->details));
         $this->assertTrue(isset($result->details->bic));
     }
@@ -113,15 +119,11 @@ class FunctionalTest extends TestCase
 
         $result = Block\await($promise, $this->loop);
 
-        $this->assertInternalType('object', $result);
+        $this->assertIsTypeObject($result);
         $this->assertFalse(isset($result->details));
         $this->assertTrue(isset($result->bic));
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExeptionMessage redirects
-     */
     public function testBlzServiceWithRedirectLocationRejectsWithRuntimeException()
     {
         $this->client = new Client(new Browser($this->loop), null, array(
@@ -132,39 +134,30 @@ class FunctionalTest extends TestCase
         $api = new Proxy($this->client);
         $promise = $api->getBank('a');
 
+        $this->setExpectedException('RuntimeException', 'redirects');
         $result = Block\await($promise, $this->loop);
     }
 
-    /**
-     * @expectedException SoapFault
-     * @expectedExeptionMessage Keine Bank zur BLZ invalid gefunden!
-     */
     public function testBlzServiceWithInvalidBlzRejectsWithSoapFault()
     {
         $api = new Proxy($this->client);
 
         $promise = $api->getBank(array('blz' => 'invalid'));
 
+        $this->setExpectedException('SoapFault', 'Keine Bank zur BLZ invalid gefunden!');
         Block\await($promise, $this->loop);
     }
 
-    /**
-     * @expectedException SoapFault
-     * @expectedExceptionMessage Function ("doesNotExist") is not a valid method for this service
-     */
     public function testBlzServiceWithInvalidMethodRejectsWithSoapFault()
     {
         $api = new Proxy($this->client);
 
         $promise = $api->doesNotExist();
 
+        $this->setExpectedException('SoapFault', 'Function ("doesNotExist") is not a valid method for this service');
         Block\await($promise, $this->loop);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage cancelled
-     */
     public function testCancelMethodRejectsWithRuntimeException()
     {
         $api = new Proxy($this->client);
@@ -172,13 +165,10 @@ class FunctionalTest extends TestCase
         $promise = $api->getBank(array('blz' => '12070000'));
         $promise->cancel();
 
+        $this->setExpectedException('RuntimeException', 'cancelled');
         Block\await($promise, $this->loop);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage timed out
-     */
     public function testTimeoutRejectsWithRuntimeException()
     {
         $browser = new Browser($this->loop);
@@ -191,6 +181,7 @@ class FunctionalTest extends TestCase
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
+        $this->setExpectedException('RuntimeException', 'timed out');
         Block\await($promise, $this->loop);
     }
 
@@ -205,19 +196,15 @@ class FunctionalTest extends TestCase
         $this->assertEquals('http://www.thomas-bayer.com/axis2/services/BLZService', $this->client->getLocation(0));
     }
 
-    /**
-     * @expectedException SoapFault
-     */
     public function testGetLocationOfUnknownFunctionNameFails()
     {
+        $this->setExpectedException('SoapFault');
         $this->client->getLocation('unknown');
     }
 
-    /**
-     * @expectedException SoapFault
-     */
     public function testGetLocationForUnknownFunctionNumberFails()
     {
+        $this->setExpectedException('SoapFault');
         $this->assertEquals('http://www.thomas-bayer.com/axis2/services/BLZService', $this->client->getLocation(100));
     }
 
@@ -239,15 +226,13 @@ class FunctionalTest extends TestCase
         $this->assertEquals($original, $this->client->getLocation(0));
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testWithLocationInvalidRejectsWithRuntimeException()
     {
         $api = new Proxy($this->client->withLocation('http://nonsense.invalid'));
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $this->loop);
     }
 
@@ -261,6 +246,34 @@ class FunctionalTest extends TestCase
         $promise = $api->getBank(array('blz' => '12070000'));
 
         $result = Block\await($promise, $this->loop);
-        $this->assertInternalType('object', $result);
+        $this->assertIsTypeObject($result);
+    }
+
+    public function assertIsTypeObject($actual)
+    {
+        if (method_exists($this, 'assertInternalType')) {
+            // legacy PHPUnit 4 - PHPUnit 7.5
+            $this->assertInternalType('object', $actual);
+        } else {
+            // PHPUnit 7.5+
+            $this->assertIsObject($actual);
+        }
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }

--- a/tests/Protocol/ClientDecoderTest.php
+++ b/tests/Protocol/ClientDecoderTest.php
@@ -5,12 +5,10 @@ use PHPUnit\Framework\TestCase;
 
 class ClientDecoderTest extends TestCase
 {
-    /**
-     * @expectedException SoapFault
-     */
     public function testDecodeThrowsSoapFaultForInvalidResponse()
     {
         $decoder = new ClientDecoder(null, array('location' => '1', 'uri' => '2'));
+        $this->setExpectedException('SoapFault');
         $decoder->decode('anything', 'invalid');
     }
 
@@ -31,5 +29,22 @@ SOAP
         $expected->plz = '14405';
 
         $this->assertEquals($expected, $res);
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.4.1 by Sebastian Bergmann and contributors.

S........................SS..                                     29 / 29 (100%)

Time: 00:01.303, Memory: 10.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 29, Assertions: 56, Skipped: 3.
```