### PR TITLE
Drop support for HHVM, PHP 5, PHPUnit 4 and PHPUnit 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ jobs:
     - php: 7.2
     - php: 7.3
     - php: 7.4
-    - php: hhvm-3.18
-  allow_failures:
-    - php: hhvm-3.18
 
 install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ dist: trusty
 
 jobs:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
     - php: 7.0
     - php: 7.1
     - php: 7.2

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ $ composer require clue/soap-react:^1.0
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus only requires `ext-soap` and
-supports running on legacy PHP 5.3 through current PHP 7+ and HHVM.
+supports running on legacy PHP 5.3 through current PHP 7+.
 It's *highly recommended to use PHP 7+* for this project.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -408,8 +408,7 @@ $ composer require clue/soap-react:^1.0
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus only requires `ext-soap` and
-supports running on legacy PHP 5.3 through current PHP 7+.
-It's *highly recommended to use PHP 7+* for this project.
+supports running on PHP 7+.
 
 ## Tests
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
     },
     "require-dev": {
         "clue/block-react": "^1.0",
-        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^6.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr-4": { "Clue\\Tests\\React\\Soap\\": "tests/" }
     },
     "require": {
-        "php": ">=5.3",
+        "php": ">=7.0",
         "react/http": "^1.0",
         "react/promise": "^2.1 || ^1.2",
         "ext-soap": "*"

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,7 +2,7 @@
 
 <!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>


### PR DESCRIPTION
The latest version of HHVM is not able to execute composer anymore.
Due to some disturbance with PHP 5 Versions we decided to drop this support as well. As a consequence we don't need the support for PHPUnit 4 and PHPUnit 5 any more.
