### PR TITLE
Fix failing tests when ext-xdebug is not loaded and simplify tests for new Xdebug and PHPUnit versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,10 @@ try {
 }
 ```
 
-> Note that if you have `ext-xdebug` loaded, this may halt with a fatal
-  error instead of throwing a `SoapFault`. It is not recommended to use this
-  extension in production, so this should only ever affect test environments.
+> Note that if you have an old version of `ext-xdebug` < 2.7 loaded, this may
+  halt with a fatal error instead of throwing a `SoapFault`. It is not
+  recommended to use this extension in production, so this should only ever
+  affect test environments.
 
 The `Client` constructor accepts an array of options. All given options will
 be passed through to the underlying `SoapClient`. However, not all options

--- a/src/Client.php
+++ b/src/Client.php
@@ -82,9 +82,10 @@ use React\Promise\PromiseInterface;
  * }
  * ```
  *
- * > Note that if you have `ext-xdebug` loaded, this may halt with a fatal
- *   error instead of throwing a `SoapFault`. It is not recommended to use this
- *   extension in production, so this should only ever affect test environments.
+ * > Note that if you have an old version of `ext-xdebug` < 2.7 loaded, this may
+ *   halt with a fatal error instead of throwing a `SoapFault`. It is not
+ *   recommended to use this extension in production, so this should only ever
+ *   affect test environments.
  *
  * The `Client` constructor accepts an array of options. All given options will
  * be passed through to the underlying `SoapClient`. However, not all options

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,8 +10,8 @@ class ClientTest extends TestCase
 {
     public function testConstructorThrowsWhenUrlIsInvalid()
     {
-        if (extension_loaded('xdebug')) {
-            $this->markTestSkipped('Invalid WSDL causes a fatal error when ext-xdebug is loaded');
+        if (extension_loaded('xdebug') && phpversion('xdebug') < 2.7) {
+            $this->markTestSkipped('Invalid WSDL causes a fatal error when ext-xdebug < 2.7 is loaded');
         }
 
         $browser = $this->getMockBuilder('React\Http\Browser')->disableOriginalConstructor()->getMock();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
 
         $wsdl = 'invalid';
 
-        $this->setExpectedException('SoapFault');
+        $this->expectException(\SoapFault::class);
         new Client($browser, $wsdl);
     }
 
@@ -58,22 +58,5 @@ class ClientTest extends TestCase
         $client = new Client($browser, null, array('location' => 'http://example.com', 'uri' => 'http://example.com/uri'));
 
         $client->soapCall('ping', array());
-    }
-
-    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
-    {
-        if (method_exists($this, 'expectException')) {
-            // PHPUnit 5+
-            $this->expectException($exception);
-            if ($exceptionMessage !== '') {
-                $this->expectExceptionMessage($exceptionMessage);
-            }
-            if ($exceptionCode !== null) {
-                $this->expectExceptionCode($exceptionCode);
-            }
-        } else {
-            // legacy PHPUnit 4
-            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
-        }
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -8,10 +8,6 @@ use React\Promise\Promise;
 
 class ClientTest extends TestCase
 {
-
-    /**
-     * @expectedException SoapFault
-     */
     public function testConstructorThrowsWhenUrlIsInvalid()
     {
         if (extension_loaded('xdebug')) {
@@ -19,15 +15,18 @@ class ClientTest extends TestCase
         }
 
         $browser = $this->getMockBuilder('React\Http\Browser')->disableOriginalConstructor()->getMock();
+        $browser->expects($this->once())->method('withRejectErrorResponse')->willReturnSelf();
+        $browser->expects($this->once())->method('withFollowRedirects')->willReturnSelf();
+
         $wsdl = 'invalid';
 
-        $client = new Client($browser, $wsdl);
+        $this->setExpectedException('SoapFault');
+        new Client($browser, $wsdl);
     }
 
     public function testNonWsdlClientReturnsSameLocationOptionForAnyFunction()
     {
         $browser = $this->getMockBuilder('React\Http\Browser')->disableOriginalConstructor()->getMock();
-
         $browser->expects($this->once())->method('withRejectErrorResponse')->willReturnSelf();
         $browser->expects($this->once())->method('withFollowRedirects')->willReturnSelf();
 
@@ -39,7 +38,6 @@ class ClientTest extends TestCase
     public function testNonWsdlClientReturnsNoTypesAndFunctions()
     {
         $browser = $this->getMockBuilder('React\Http\Browser')->disableOriginalConstructor()->getMock();
-
         $browser->expects($this->once())->method('withRejectErrorResponse')->willReturnSelf();
         $browser->expects($this->once())->method('withFollowRedirects')->willReturnSelf();
 
@@ -60,5 +58,22 @@ class ClientTest extends TestCase
         $client = new Client($browser, null, array('location' => 'http://example.com', 'uri' => 'http://example.com/uri'));
 
         $client->soapCall('ping', array());
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -134,8 +134,9 @@ class FunctionalTest extends TestCase
         $api = new Proxy($this->client);
         $promise = $api->getBank('a');
 
-        $this->setExpectedException('RuntimeException', 'redirects');
-        $result = Block\await($promise, $this->loop);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('redirects');
+        Block\await($promise, $this->loop);
     }
 
     public function testBlzServiceWithInvalidBlzRejectsWithSoapFault()
@@ -144,7 +145,8 @@ class FunctionalTest extends TestCase
 
         $promise = $api->getBank(array('blz' => 'invalid'));
 
-        $this->setExpectedException('SoapFault', 'Keine Bank zur BLZ invalid gefunden!');
+        $this->expectException(\SoapFault::class);
+        $this->expectExceptionMessage('Keine Bank zur BLZ invalid gefunden!');
         Block\await($promise, $this->loop);
     }
 
@@ -154,7 +156,8 @@ class FunctionalTest extends TestCase
 
         $promise = $api->doesNotExist();
 
-        $this->setExpectedException('SoapFault', 'Function ("doesNotExist") is not a valid method for this service');
+        $this->expectException(\SoapFault::class);
+        $this->expectExceptionMessage('Function ("doesNotExist") is not a valid method for this service');
         Block\await($promise, $this->loop);
     }
 
@@ -165,7 +168,8 @@ class FunctionalTest extends TestCase
         $promise = $api->getBank(array('blz' => '12070000'));
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'cancelled');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('cancelled');
         Block\await($promise, $this->loop);
     }
 
@@ -179,7 +183,8 @@ class FunctionalTest extends TestCase
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
-        $this->setExpectedException('RuntimeException', 'timed out');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('timed out');
         Block\await($promise, $this->loop);
     }
 
@@ -196,13 +201,13 @@ class FunctionalTest extends TestCase
 
     public function testGetLocationOfUnknownFunctionNameFails()
     {
-        $this->setExpectedException('SoapFault');
+        $this->expectException(\SoapFault::class);
         $this->client->getLocation('unknown');
     }
 
     public function testGetLocationForUnknownFunctionNumberFails()
     {
-        $this->setExpectedException('SoapFault');
+        $this->expectException(\SoapFault::class);
         $this->assertEquals('http://www.thomas-bayer.com/axis2/services/BLZService', $this->client->getLocation(100));
     }
 
@@ -230,7 +235,7 @@ class FunctionalTest extends TestCase
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         Block\await($promise, $this->loop);
     }
 
@@ -255,23 +260,6 @@ class FunctionalTest extends TestCase
         } else {
             // PHPUnit 7.5+
             $this->assertIsObject($actual);
-        }
-    }
-
-    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
-    {
-        if (method_exists($this, 'expectException')) {
-            // PHPUnit 5+
-            $this->expectException($exception);
-            if ($exceptionMessage !== '') {
-                $this->expectExceptionMessage($exceptionMessage);
-            }
-            if ($exceptionCode !== null) {
-                $this->expectExceptionCode($exceptionCode);
-            }
-        } else {
-            // legacy PHPUnit 4
-            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
         }
     }
 }

--- a/tests/Protocol/ClientDecoderTest.php
+++ b/tests/Protocol/ClientDecoderTest.php
@@ -8,7 +8,8 @@ class ClientDecoderTest extends TestCase
     public function testDecodeThrowsSoapFaultForInvalidResponse()
     {
         $decoder = new ClientDecoder(null, array('location' => '1', 'uri' => '2'));
-        $this->setExpectedException('SoapFault');
+
+        $this->expectException(\SoapFault::class);
         $decoder->decode('anything', 'invalid');
     }
 
@@ -29,22 +30,5 @@ SOAP
         $expected->plz = '14405';
 
         $this->assertEquals($expected, $res);
-    }
-
-    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
-    {
-        if (method_exists($this, 'expectException')) {
-            // PHPUnit 5+
-            $this->expectException($exception);
-            if ($exceptionMessage !== '') {
-                $this->expectExceptionMessage($exceptionMessage);
-            }
-            if ($exceptionCode !== null) {
-                $this->expectExceptionCode($exceptionCode);
-            }
-        } else {
-            // legacy PHPUnit 4
-            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
-        }
     }
 }

--- a/tests/Protocol/ClientEncoderTest.php
+++ b/tests/Protocol/ClientEncoderTest.php
@@ -38,8 +38,8 @@ class ClientEncoderTest extends TestCase
 
     public function testConstructorThrowsWhenUrlIsInvalid()
     {
-        if (extension_loaded('xdebug')) {
-            $this->markTestSkipped('Invalid WSDL causes a fatal error when ext-xdebug is loaded');
+        if (extension_loaded('xdebug') && phpversion('xdebug') < 2.7) {
+            $this->markTestSkipped('Invalid WSDL causes a fatal error when ext-xdebug < 2.7 is loaded');
         }
 
         $this->expectException(\SoapFault::class);
@@ -48,8 +48,8 @@ class ClientEncoderTest extends TestCase
 
     public function testConstructorThrowsWhenNonWsdlDoesNotDefineLocationAndUri()
     {
-        if (extension_loaded('xdebug')) {
-            $this->markTestSkipped('Invalid non-WSDL mode causes a fatal error when ext-xdebug is loaded');
+        if (extension_loaded('xdebug') && phpversion('xdebug') < 2.7) {
+            $this->markTestSkipped('Invalid non-WSDL mode causes a fatal error when ext-xdebug < 2.7 is loaded');
         }
 
         $this->expectException(\SoapFault::class);

--- a/tests/Protocol/ClientEncoderTest.php
+++ b/tests/Protocol/ClientEncoderTest.php
@@ -36,27 +36,23 @@ class ClientEncoderTest extends TestCase
         $this->assertFalse($request->hasHeader('SOAPAction'));
     }
 
-    /**
-     * @expectedException SoapFault
-     */
     public function testConstructorThrowsWhenUrlIsInvalid()
     {
         if (extension_loaded('xdebug')) {
             $this->markTestSkipped('Invalid WSDL causes a fatal error when ext-xdebug is loaded');
         }
 
+        $this->setExpectedException('SoapFault');
         new ClientEncoder('invalid');
     }
 
-    /**
-     * @expectedException SoapFault
-     */
     public function testConstructorThrowsWhenNonWsdlDoesNotDefineLocationAndUri()
     {
         if (extension_loaded('xdebug')) {
             $this->markTestSkipped('Invalid non-WSDL mode causes a fatal error when ext-xdebug is loaded');
         }
 
+        $this->setExpectedException('SoapFault');
         new ClientEncoder(null);
     }
 
@@ -79,5 +75,22 @@ class ClientEncoderTest extends TestCase
 ';
 
         $this->assertEquals($expected, (string)$request->getBody());
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }

--- a/tests/Protocol/ClientEncoderTest.php
+++ b/tests/Protocol/ClientEncoderTest.php
@@ -42,7 +42,7 @@ class ClientEncoderTest extends TestCase
             $this->markTestSkipped('Invalid WSDL causes a fatal error when ext-xdebug is loaded');
         }
 
-        $this->setExpectedException('SoapFault');
+        $this->expectException(\SoapFault::class);
         new ClientEncoder('invalid');
     }
 
@@ -52,7 +52,7 @@ class ClientEncoderTest extends TestCase
             $this->markTestSkipped('Invalid non-WSDL mode causes a fatal error when ext-xdebug is loaded');
         }
 
-        $this->setExpectedException('SoapFault');
+        $this->expectException(\SoapFault::class);
         new ClientEncoder(null);
     }
 
@@ -75,22 +75,5 @@ class ClientEncoderTest extends TestCase
 ';
 
         $this->assertEquals($expected, (string)$request->getBody());
-    }
-
-    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
-    {
-        if (method_exists($this, 'expectException')) {
-            // PHPUnit 5+
-            $this->expectException($exception);
-            if ($exceptionMessage !== '') {
-                $this->expectExceptionMessage($exceptionMessage);
-            }
-            if ($exceptionCode !== null) {
-                $this->expectExceptionCode($exceptionCode);
-            }
-        } else {
-            // legacy PHPUnit 4
-            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
-        }
     }
 }


### PR DESCRIPTION
This changeset fixes failing tests when ext-xdebug is not loaded and simplifies tests for new Xdebug and PHPUnit versions. This fixes a small oversight from #44. The additional simplification is possible as of #47. The affected tests do not need to be skipped anymore with ext-xdebug 2.7 as per https://bugs.xdebug.org/bug_view_page.php?bug_id=00001629