### PR TITLE
Add type declarations and require PHP 7.1+ as a consequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 
 jobs:
   include:
-    - php: 7.0
     - php: 7.1
     - php: 7.2
     - php: 7.3

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ $ composer require clue/soap-react:^1.0
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus only requires `ext-soap` and
-supports running on PHP 7+.
+supports running on PHP 7.1+.
 
 ## Tests
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr-4": { "Clue\\Tests\\React\\Soap\\": "tests/" }
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "react/http": "^1.0",
         "react/promise": "^2.1 || ^1.2",
         "ext-soap": "*"

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
     },
     "require-dev": {
         "clue/block-react": "^1.0",
-        "phpunit/phpunit": "^9.3 || ^6.5"
+        "phpunit/phpunit": "^9.3 || ^7.5"
     }
 }

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,7 +2,7 @@
 
 <!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>

--- a/src/Client.php
+++ b/src/Client.php
@@ -157,7 +157,7 @@ class Client
      * @param string|null $wsdlContents
      * @param array       $options
      */
-    public function __construct(Browser $browser, $wsdlContents, array $options = array())
+    public function __construct(Browser $browser, ?string $wsdlContents, array $options = array())
     {
         $wsdl = $wsdlContents !== null ? 'data://text/plain;base64,' . base64_encode($wsdlContents) : null;
 
@@ -192,7 +192,7 @@ class Client
      * @param mixed[] $args
      * @return PromiseInterface Returns a Promise<mixed, Exception>
      */
-    public function soapCall($name, $args)
+    public function soapCall(string $name, array $args): PromiseInterface
     {
         try {
             $request = $this->encoder->encode($name, $args);
@@ -226,7 +226,7 @@ class Client
      *
      * @return string[]|null
      */
-    public function getFunctions()
+    public function getFunctions(): ?array
     {
         return $this->encoder->__getFunctions();
     }
@@ -240,7 +240,7 @@ class Client
      *
      * @return string[]|null
      */
-    public function getTypes()
+    public function getTypes(): ?array
     {
         return $this->encoder->__getTypes();
     }
@@ -281,7 +281,7 @@ class Client
      * @throws \SoapFault if given function does not exist
      * @see self::getFunctions()
      */
-    public function getLocation($function)
+    public function getLocation($function): string
     {
         if (is_int($function)) {
             $functions = $this->getFunctions();
@@ -315,7 +315,7 @@ class Client
      * @return self
      * @see self::getLocation()
      */
-    public function withLocation($location)
+    public function withLocation(string $location): self
     {
         $client = clone $this;
         $client->encoder = clone $this->encoder;

--- a/src/Protocol/ClientDecoder.php
+++ b/src/Protocol/ClientDecoder.php
@@ -2,12 +2,10 @@
 
 namespace Clue\React\Soap\Protocol;
 
-use \SoapClient;
-
 /**
  * @internal
  */
-final class ClientDecoder extends SoapClient
+final class ClientDecoder extends \SoapClient
 {
     private $response = null;
 
@@ -19,7 +17,7 @@ final class ClientDecoder extends SoapClient
      * @return mixed
      * @throws \SoapFault if response indicates a fault (error condition) or is invalid
      */
-    public function decode($function, $response)
+    public function decode(string $function, string $response)
     {
         // Temporarily save response internally for further processing
         $this->response = $response;
@@ -42,7 +40,7 @@ final class ClientDecoder extends SoapClient
      * the return code in this method. This will implicitly be invoked by the
      * call to `pseudoCall()` in the above `decode()` method.
      *
-     * @see SoapClient::__doRequest()
+     * @see \SoapClient::__doRequest()
      */
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -2,13 +2,13 @@
 
 namespace Clue\React\Soap\Protocol;
 
-use \SoapClient;
+use Psr\Http\Message\RequestInterface;
 use RingCentral\Psr7\Request;
 
 /**
  * @internal
  */
-final class ClientEncoder extends SoapClient
+final class ClientEncoder extends \SoapClient
 {
     private $request = null;
 
@@ -16,11 +16,11 @@ final class ClientEncoder extends SoapClient
      * Encodes the given RPC function name and arguments as a SOAP request
      *
      * @param string $name
-     * @param array $args
-     * @return \Psr\Http\Message\RequestInterface
+     * @param array  $args
+     * @return RequestInterface
      * @throws \SoapFault if request is invalid according to WSDL
      */
-    public function encode($name, $args)
+    public function encode(string $name, array $args): RequestInterface
     {
         $this->__soapCall($name, $args);
 
@@ -40,7 +40,7 @@ final class ClientEncoder extends SoapClient
      * This will implicitly be invoked by the call to `__soapCall()` in the
      * above `encode()` method.
      *
-     * @see SoapClient::__doRequest()
+     * @see \SoapClient::__doRequest()
      */
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -43,7 +43,7 @@ final class Proxy
      * @param mixed[] $args
      * @return PromiseInterface
      */
-    public function __call($name, $args)
+    public function __call(string $name, array $args): PromiseInterface
     {
         return $this->client->soapCall($name, $args);
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -57,7 +57,7 @@ class FunctionalTest extends TestCase
 
         $result = Block\await($promise, $this->loop);
 
-        $this->assertIsTypeObject($result);
+        $this->assertIsObject($result);
         $this->assertTrue(isset($result->details));
         $this->assertTrue(isset($result->details->bic));
     }
@@ -99,7 +99,7 @@ class FunctionalTest extends TestCase
 
         $result = Block\await($promise, $this->loop);
 
-        $this->assertIsTypeObject($result);
+        $this->assertIsObject($result);
         $this->assertTrue(isset($result->details));
         $this->assertTrue(isset($result->details->bic));
     }
@@ -119,7 +119,7 @@ class FunctionalTest extends TestCase
 
         $result = Block\await($promise, $this->loop);
 
-        $this->assertIsTypeObject($result);
+        $this->assertIsObject($result);
         $this->assertFalse(isset($result->details));
         $this->assertTrue(isset($result->bic));
     }
@@ -249,17 +249,6 @@ class FunctionalTest extends TestCase
         $promise = $api->getBank(array('blz' => '12070000'));
 
         $result = Block\await($promise, $this->loop);
-        $this->assertIsTypeObject($result);
-    }
-
-    public function assertIsTypeObject($actual)
-    {
-        if (method_exists($this, 'assertInternalType')) {
-            // legacy PHPUnit 4 - PHPUnit 7.5
-            $this->assertInternalType('object', $actual);
-        } else {
-            // PHPUnit 7.5+
-            $this->assertIsObject($actual);
-        }
+        $this->assertIsObject($result);
     }
 }


### PR DESCRIPTION
This changeset adds type declarations and requires PHP 7.1+ as a consequence.

Builds on top of #47 and #48