### PR TITLE
 Simplify usage by updating to new default loop and making Browser optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,27 +94,23 @@ The `Client` class is responsible for communication with the remote SOAP
 WebService server. It requires the WSDL file contents and an optional
 array of SOAP options:
 
-It requires a [`Browser`](https://github.com/reactphp/http#browser) object
-bound to the main [`EventLoop`](https://github.com/reactphp/event-loop#usage)
-in order to handle async requests, the WSDL file contents and an optional
-array of SOAP options:
-
 ```php
-$browser = new React\Http\Browser();
-
 $wsdl = '<?xml …';
 $options = array();
 
-$client = new Clue\React\Soap\Client($browser, $wsdl, $options);
+$client = new Clue\React\Soap\Client(null, $wsdl, $options);
 ```
 
+This class takes an optional `Browser|null $browser` parameter that can be used to
+pass the browser instance to use for this object.
 If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
 proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface)
-to the [`Browser`](https://github.com/reactphp/http#browser) instance:
+to the [`Browser`](https://github.com/reactphp/http#browser) instance
+and pass it as an additional argument to the `Client` like this:
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => '127.0.0.1',
     'tcp' => array(
         'bindto' => '192.168.10.1:0'
@@ -125,7 +121,7 @@ $connector = new React\Socket\Connector(null, array(
     )
 ));
 
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 $client = new Clue\React\Soap\Client($browser, $wsdl);
 ```
 
@@ -156,7 +152,7 @@ parsed, this will throw a `SoapFault`:
 
 ```php
 try {
-    $client = new Clue\React\Soap\Client($browser, $wsdl);
+    $client = new Clue\React\Soap\Client(null, $wsdl);
 } catch (SoapFault $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 }
@@ -180,7 +176,7 @@ the URL of the SOAP server to send the request to, and `uri` is the target
 namespace of the SOAP service:
 
 ```php
-$client = new Clue\React\Soap\Client($browser, null, array(
+$client = new Clue\React\Soap\Client(null, null, array(
     'location' => 'http://example.com',
     'uri' => 'http://ping.example.com',
 ));
@@ -190,7 +186,7 @@ Similarly, if working in WSDL mode, the `location` option can be used to
 explicitly overwrite the URL of the SOAP server to send the request to:
 
 ```php
-$client = new Clue\React\Soap\Client($browser, $wsdl, array(
+$client = new Clue\React\Soap\Client(null, $wsdl, array(
     'location' => 'http://example.com'
 ));
 ```
@@ -199,7 +195,7 @@ You can use the `soap_version` option to change from the default SOAP 1.1 to
 use SOAP 1.2 instead:
 
 ```php
-$client = new Clue\React\Soap\Client($browser, $wsdl, array(
+$client = new Clue\React\Soap\Client(null, $wsdl, array(
     'soap_version' => SOAP_1_2
 ));
 ```
@@ -208,7 +204,7 @@ You can use the `classmap` option to map certain WSDL types to PHP classes
 like this:
 
 ```php
-$client = new Clue\React\Soap\Client($browser, $wsdl, array(
+$client = new Clue\React\Soap\Client(null, $wsdl, array(
     'classmap' => array(
         'getBankResponseType' => BankResponse::class
     )

--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ Once [installed](#install), you can use the following code to query an example
 web service via SOAP:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+$browser = new React\Http\Browser();
 $wsdl = 'http://example.com/demo.wsdl';
 
 $browser->get($wsdl)->then(function (Psr\Http\Message\ResponseInterface $response) use ($browser) {
@@ -79,8 +82,6 @@ $browser->get($wsdl)->then(function (Psr\Http\Message\ResponseInterface $respons
         var_dump('Result', $result);
     });
 });
-
-$loop->run();
 ```
 
 See also the [examples](examples).
@@ -90,7 +91,8 @@ See also the [examples](examples).
 ### Client
 
 The `Client` class is responsible for communication with the remote SOAP
-WebService server.
+WebService server. It requires the WSDL file contents and an optional
+array of SOAP options:
 
 It requires a [`Browser`](https://github.com/reactphp/http#browser) object
 bound to the main [`EventLoop`](https://github.com/reactphp/event-loop#usage)
@@ -98,8 +100,7 @@ in order to handle async requests, the WSDL file contents and an optional
 array of SOAP options:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $wsdl = '<?xml …';
 $options = array();
@@ -113,7 +114,7 @@ proxy servers etc.), you can explicitly pass a custom instance of the
 to the [`Browser`](https://github.com/reactphp/http#browser) instance:
 
 ```php
-$connector = new React\Socket\Connector($loop, array(
+$connector = new React\Socket\Connector(null, array(
     'dns' => '127.0.0.1',
     'tcp' => array(
         'bindto' => '192.168.10.1:0'
@@ -124,7 +125,7 @@ $connector = new React\Socket\Connector($loop, array(
     )
 ));
 
-$browser = new React\Http\Browser($loop, $connector);
+$browser = new React\Http\Browser(null, $connector);
 $client = new Clue\React\Soap\Client($browser, $wsdl);
 ```
 
@@ -134,7 +135,7 @@ you to use local WSDL files, WSDL files from a cache or the most common form,
 downloading the WSDL file contents from an URL through the `Browser`:
 
 ```php
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $browser->get($url)->then(
     function (Psr\Http\Message\ResponseInterface $response) use ($browser) {
@@ -366,7 +367,7 @@ clean up any underlying resources.
 ```php
 $promise = $proxy->demo();
 
-$loop->addTimer(2.0, function () use ($promise) {
+Loop::addTimer(2.0, function () use ($promise) {
     $promise->cancel();
 });
 ```
@@ -389,7 +390,7 @@ pass the timeout to the [underlying `Browser`](https://github.com/reactphp/http#
 like this:
 
 ```php
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 $browser = $browser->withTimeout(10.0);
 
 $client = new Clue\React\Soap\Client($browser, $wsdl);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "react/http": "^1.0",
+        "react/http": "^1.5",
         "react/promise": "^2.1 || ^1.2",
         "ext-soap": "*"
     },

--- a/examples/01-client-blz-wsdl.php
+++ b/examples/01-client-blz-wsdl.php
@@ -2,8 +2,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $blz = isset($argv[1]) ? $argv[1] : '12070000';
 
@@ -21,5 +20,3 @@ $browser->get('http://www.thomas-bayer.com/axis2/services/BLZService?wsdl')->don
         }
     );
 });
-
-$loop->run();

--- a/examples/02-client-blz-non-wsdl.php
+++ b/examples/02-client-blz-non-wsdl.php
@@ -2,11 +2,9 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$browser = new React\Http\Browser();
-
 $blz = isset($argv[1]) ? $argv[1] : '12070000';
 
-$client = new Clue\React\Soap\Client($browser, null, array(
+$client = new Clue\React\Soap\Client(null, null, array(
     'location' => 'http://www.thomas-bayer.com/axis2/services/BLZService',
     'uri' => 'http://thomas-bayer.com/blz/',
     'use' => SOAP_LITERAL

--- a/examples/02-client-blz-non-wsdl.php
+++ b/examples/02-client-blz-non-wsdl.php
@@ -2,8 +2,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $blz = isset($argv[1]) ? $argv[1] : '12070000';
 
@@ -23,5 +22,3 @@ $api->getBank(new SoapVar($blz, XSD_STRING, null, null, 'blz', 'http://thomas-ba
         echo 'ERROR: ' . $e->getMessage() . PHP_EOL;
     }
 );
-
-$loop->run();

--- a/examples/11-wsdl-info.php
+++ b/examples/11-wsdl-info.php
@@ -2,8 +2,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $wsdl = isset($argv[1]) ? $argv[1] : 'http://www.thomas-bayer.com/axis2/services/BLZService?wsdl';
 
@@ -21,5 +20,3 @@ $browser->get($wsdl)->done(
         echo 'Error: ' . $e->getMessage() . PHP_EOL;
     }
 );
-
-$loop->run();

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,8 +19,7 @@ use React\Promise\PromiseInterface;
  * array of SOAP options:
  *
  * ```php
- * $loop = React\EventLoop\Factory::create();
- * $browser = new React\Http\Browser($loop);
+ * $browser = new React\Http\Browser();
  *
  * $wsdl = '<?xml …';
  * $options = array();
@@ -34,7 +33,7 @@ use React\Promise\PromiseInterface;
  * to the [`Browser`](https://github.com/clue/reactphp/http#browser) instance:
  *
  * ```php
- * $connector = new React\Socket\Connector($loop, array(
+ * $connector = new React\Socket\Connector(null, array(
  *     'dns' => '127.0.0.1',
  *     'tcp' => array(
  *         'bindto' => '192.168.10.1:0'
@@ -45,7 +44,7 @@ use React\Promise\PromiseInterface;
  *     )
  * ));
  *
- * $browser = new React\Http\Browser($loop, $connector);
+ * $browser = new React\Http\Browser(null, $connector);
  * $client = new Clue\React\Soap\Client($browser, $wsdl);
  * ```
  *
@@ -55,7 +54,7 @@ use React\Promise\PromiseInterface;
  * downloading the WSDL file contents from an URL through the `Browser`:
  *
  * ```php
- * $browser = new React\Http\Browser($loop);
+ * $browser = new React\Http\Browser();
  *
  * $browser->get($url)->then(
  *     function (Psr\Http\Message\ResponseInterface $response) use ($browser) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,29 +11,26 @@ use React\Promise\PromiseInterface;
 
 /**
  * The `Client` class is responsible for communication with the remote SOAP
- * WebService server.
- *
- * It requires a [`Browser`](https://github.com/reactphp/http#browser) object
- * bound to the main [`EventLoop`](https://github.com/reactphp/event-loop#usage)
- * in order to handle async requests, the WSDL file contents and an optional
+ * WebService server. It requires the WSDL file contents and an optional
  * array of SOAP options:
  *
  * ```php
- * $browser = new React\Http\Browser();
- *
  * $wsdl = '<?xml …';
  * $options = array();
  *
- * $client = new Clue\React\Soap\Client($browser, $wsdl, $options);
+ * $client = new Clue\React\Soap\Client(null, $wsdl, $options);
  * ```
  *
+ * This class takes an optional `Browser|null $browser` parameter that can be used to
+ * pass the browser instance to use for this object.
  * If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
  * proxy servers etc.), you can explicitly pass a custom instance of the
  * [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface)
- * to the [`Browser`](https://github.com/clue/reactphp/http#browser) instance:
+ * to the [`Browser`](https://github.com/reactphp/http#browser) instance
+ * and pass it as an additional argument to the `Client` like this:
  *
  * ```php
- * $connector = new React\Socket\Connector(null, array(
+ * $connector = new React\Socket\Connector(array(
  *     'dns' => '127.0.0.1',
  *     'tcp' => array(
  *         'bindto' => '192.168.10.1:0'
@@ -44,7 +41,7 @@ use React\Promise\PromiseInterface;
  *     )
  * ));
  *
- * $browser = new React\Http\Browser(null, $connector);
+ * $browser = new React\Http\Browser($connector);
  * $client = new Clue\React\Soap\Client($browser, $wsdl);
  * ```
  *
@@ -75,7 +72,7 @@ use React\Promise\PromiseInterface;
  *
  * ```php
  * try {
- *     $client = new Clue\React\Soap\Client($browser, $wsdl);
+ *     $client = new Clue\React\Soap\Client(null, $wsdl);
  * } catch (SoapFault $e) {
  *     echo 'Error: ' . $e->getMessage() . PHP_EOL;
  * }
@@ -99,7 +96,7 @@ use React\Promise\PromiseInterface;
  * namespace of the SOAP service:
  *
  * ```php
- * $client = new Clue\React\Soap\Client($browser, null, array(
+ * $client = new Clue\React\Soap\Client(null, null, array(
  *     'location' => 'http://example.com',
  *     'uri' => 'http://ping.example.com',
  * ));
@@ -109,7 +106,7 @@ use React\Promise\PromiseInterface;
  * explicitly overwrite the URL of the SOAP server to send the request to:
  *
  * ```php
- * $client = new Clue\React\Soap\Client($browser, $wsdl, array(
+ * $client = new Clue\React\Soap\Client(null, $wsdl, array(
  *     'location' => 'http://example.com'
  * ));
  * ```
@@ -118,7 +115,7 @@ use React\Promise\PromiseInterface;
  * use SOAP 1.2 instead:
  *
  * ```php
- * $client = new Clue\React\Soap\Client($browser, $wsdl, array(
+ * $client = new Clue\React\Soap\Client(null, $wsdl, array(
  *     'soap_version' => SOAP_1_2
  * ));
  * ```
@@ -127,7 +124,7 @@ use React\Promise\PromiseInterface;
  * like this:
  *
  * ```php
- * $client = new Clue\React\Soap\Client($browser, $wsdl, array(
+ * $client = new Clue\React\Soap\Client(null, $wsdl, array(
  *     'classmap' => array(
  *         'getBankResponseType' => BankResponse::class
  *     )
@@ -145,29 +142,32 @@ use React\Promise\PromiseInterface;
  */
 class Client
 {
+    /** @var Browser */
     private $browser;
+
     private $encoder;
     private $decoder;
 
     /**
      * Instantiate a new SOAP client for the given WSDL contents.
      *
-     * @param Browser     $browser
-     * @param string|null $wsdlContents
-     * @param array       $options
+     * @param ?Browser $browser
+     * @param ?string  $wsdlContents
+     * @param ?array   $options
      */
-    public function __construct(Browser $browser, ?string $wsdlContents, array $options = array())
+    public function __construct(?Browser $browser, ?string $wsdlContents, array $options = array())
     {
         $wsdl = $wsdlContents !== null ? 'data://text/plain;base64,' . base64_encode($wsdlContents) : null;
+
+        $this->browser = $browser ?? new Browser();
 
         // Accept HTTP responses with error status codes as valid responses.
         // This is done in order to process these error responses through the normal SOAP decoder.
         // Additionally, we explicitly limit number of redirects to zero because following redirects makes little sense
         // because it transforms the POST request to a GET one and hence loses the SOAP request body.
-        $browser = $browser->withRejectErrorResponse(false);
-        $browser = $browser->withFollowRedirects(0);
+        $this->browser = $this->browser->withRejectErrorResponse(false);
+        $this->browser = $this->browser->withFollowRedirects(0);
 
-        $this->browser = $browser;
         $this->encoder = new ClientEncoder($wsdl, $options);
         $this->decoder = new ClientDecoder($wsdl, $options);
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -42,7 +42,7 @@ class FunctionalTest extends TestCase
      */
     public function setUpClient()
     {
-        $this->loop = \React\EventLoop\Factory::create();
+        $this->loop = \React\EventLoop\Loop::get();
         $this->client = new Client(new Browser($this->loop), self::$wsdl);
     }
 


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$browser = new React\Http\Browser($loop);
$client = new Clue\React\Soap\Client($browser, $wsdl, $options);

// new (using default loop)
$client = new Clue\React\Soap\Client(null, $wsdl, $options);
```
Builds on top of reactphp/event-loop#226, reactphp/event-loop#229, reactphp/event-loop#232, reactphp/socket#264 and reactphp/http#418